### PR TITLE
Fix required version for peewee

### DIFF
--- a/packages/dila2sql/requirements.txt
+++ b/packages/dila2sql/requirements.txt
@@ -4,7 +4,7 @@ tqdm
 aiohttp
 aiofiles
 backoff
-peewee
+peewee>=3.5.2
 psycopg2-binary
 tox
 xlrd


### PR DESCRIPTION
This version 3.5.2 is the minimum required version. The last version is 3.13.1, which also works.

With an old version like 2.10.2 there is an error during initialisation of the database "AttributeError: 'SqliteDatabase' object has no attribute 'table_exists'".

With a version >= 3.0 and < 3.5 the same method table_exists is buggy, see https://github.com/coleifer/peewee/issues/1612.